### PR TITLE
Bugfix/cert and properties

### DIFF
--- a/configurator/src/main.rs
+++ b/configurator/src/main.rs
@@ -282,12 +282,11 @@ fn main() -> Result<(), anyhow::Error> {
     }
     let config: Config = serde_yaml::from_reader(File::open("/root/.lnd/start9/config.yaml")?)?;
     let alias = get_alias(&config)?;
-    let control_tor_address: String = config.control_tor_address;
-    let watchtower_tor_address: String = config.watchtower_tor_address;
-    let peer_tor_address: String = config.peer_tor_address;
-    let args: Vec<String> = env::args().collect();
-    if args.len() > 1 {
-        if args[1] == "properties" {
+    let control_tor_address = config.control_tor_address;
+    let watchtower_tor_address = config.watchtower_tor_address;
+    let peer_tor_address = config.peer_tor_address;
+    if let Some(cmd) = env::args().skip(1).next() {
+        if cmd == "properties" {
             properties(control_tor_address, peer_tor_address);
             return Ok(());
         }
@@ -483,8 +482,6 @@ fn main() -> Result<(), anyhow::Error> {
         std::thread::sleep(std::time::Duration::from_secs(1));
     }
     std::fs::hard_link(cert_path, &cert_link)?;
-    // println!("creating cert file... ");
-    // File::create("/root/.lnd/public/tls.cert")?.write_all(tls_cert.as_bytes())?;
 
     let use_channel_backup_data = match restore_info(Path::new("/root/.lnd"))? {
         None => Ok(None::<serde_json::Value>),

--- a/docker_entrypoint.sh
+++ b/docker_entrypoint.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+set -e
+
 export HOST_IP=$(ip -4 route list match 0/0 | awk '{print $3}')
 export CONTAINER_IP=$(ifconfig | sed -En 's/127.0.0.1//;s/.*inet (addr:)?(([0-9]*\.){3}[0-9]*).*/\2/p')
 

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -70,15 +70,15 @@ config: # if you dont provide an io format in cases like config where its necess
     io-format: yaml # necessary in this case 
 properties:
   type: docker
-  image: compat
-  system: true
-  entrypoint: compat
+  image: main
+  system: false
+  entrypoint: configurator
   args:
     - properties
-    - /root/.lnd
   mounts:
     main: /root/.lnd
   io-format: yaml
+  inject: false
 volumes:
   # this is the image where data will go from 0.2.x
   main:


### PR DESCRIPTION
Fixes https://github.com/Start9Labs/lnd-wrapper/issues/35, #29, and #31.

Refactors public tls cert to be a hard link instead of a copy, so that it is always valid.

Refactors properties to be a `docker run` action. This feature prints a fallback message if the rpc is unreachable, and saves the results of the getinfo call on success in stats.yaml. In case the getinfo call fails on a subsequent visit to the properties page, the contents of stats.yaml are returned.

Add a 5-second delay to the wallet unlocking loop so the logs aren't spammed with wallet unlocking errors.