### PR TITLE
disables autofill for tls SANs

### DIFF
--- a/configurator/src/lnd.conf.template
+++ b/configurator/src/lnd.conf.template
@@ -2,6 +2,7 @@
 tlsextradomain={control_tor_address}
 tlsextradomain=lnd.embassy
 tlsautorefresh=true
+tlsdisableautofill=true
 externalhosts={control_tor_address}
 payments-expiration-grace-period={payments_expiration_grace_period}s
 listen=0.0.0.0:9735


### PR DESCRIPTION
There's no ticket for this. The problem is that the cert would rotate on drive attachment, system rebuild, and other such actions that can cause a change in the IP of the container. This change excludes the IP from the cert which will prevent LND from regenerating it in those circumstances. This will ultimately smooth out Thunderhub and RTL in those scenarios.