### PR TITLE
Add Alby to list of compatible wallets

### DIFF
--- a/docs/wallets.md
+++ b/docs/wallets.md
@@ -6,8 +6,8 @@
 
 ### Instructions
 1. Install RTL on the Embassy
-1. Copy/paste your RTL Tor Address into any Tor-enabled browser
-1. Copy/paste your password (located in `Properties`) into your RTL website
+2. Copy/paste your RTL Tor Address into any Tor-enabled browser
+3. Copy/paste your password (located in `Properties`) into your RTL website
 
 ## [Zap](https://github.com/LN-Zap/)
 
@@ -23,3 +23,17 @@ Zap is designed to work with a remote LND node but has issues when connecting ov
 
 ### Instructions
 View the [tutorial](/docs/integrations/zap) for mobile app integrations.
+
+## [Alby](https://getalby.com)
+
+### Available for
+Most desktop web browsers.
+
+### Instructions
+1. Visit [getalby.com](https://getalby.com) and install the browser extenstion
+2. Install the native companion [app](https://github.com/getAlby/alby-companion-rs) (for connecting over tor)
+3. Launch Alby from your browser and follow the onboarding steps
+4. Select Start9 from the node connection options
+5. Enter your `LND Connect REST URL` from the Properties tab of your Lightning Network Daemon service on your Embassy (currently c-lightning is not yet supported on Alby)
+6. Finish the onboarding steps and your Embassy lightning node is now connected to the Alby wallet!
+7. For a list of some sites you can interact with visit [makers.bolt.fun](https://makers.bolt.fun)


### PR DESCRIPTION
I added Alby to the list of compatible wallets, we have recently added a Start9 (Embassy) connector as an option when setting up Alby to make it easy for plug and play node users.

Screenshot of Embassy connector in Alby:
![image](https://user-images.githubusercontent.com/85003930/159359564-ba857c5f-9bf6-4081-b823-011c9cb647b4.png)

I also noticed that the steps for connecting RTL were numbered incorrectly so I also fixed that.