### PR TITLE
check success code before parsing stdout

### DIFF
--- a/configurator/src/main.rs
+++ b/configurator/src/main.rs
@@ -686,6 +686,7 @@ fn main() -> Result<(), anyhow::Error> {
             .arg(format!("{}", serde_json::json!({})))
             .output()?;
         if !output.status.success() {
+            eprintln!("{}", std::str::from_utf8(&output.stderr)?);
             return Err(anyhow::anyhow!("Error generating seed. Exiting."));
         }
         let CipherSeedMnemonic {

--- a/configurator/src/main.rs
+++ b/configurator/src/main.rs
@@ -685,7 +685,9 @@ fn main() -> Result<(), anyhow::Error> {
             .arg("-d")
             .arg(format!("{}", serde_json::json!({})))
             .output()?;
-        eprint!("{}", std::str::from_utf8(&output.stderr)?);
+        if !output.status.success() {
+            return Err(anyhow::anyhow!("Error generating seed. Exiting."));
+        }
         let CipherSeedMnemonic {
             cipher_seed_mnemonic,
         } = serde_json::from_slice(&output.stdout)?;


### PR DESCRIPTION
Fixes an issue where we would try to parse the output of the genseed command even if we had an unsuccessful seed generation attempt. Fixes #53 