### PR TITLE
update to LND v0.15.0 and added circular route option

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,8 +14,9 @@ S9PK_PATH=$(shell find . -name lnd.s9pk -print)
 all: verify
 
 clean:
-	rm lnd.s9pk
-	rm image.tar
+	rm -f lnd.s9pk
+	rm -f image.tar
+	rm -f scripts/*.js
 
 verify: lnd.s9pk $(S9PK_PATH)
 	embassy-sdk verify s9pk $(S9PK_PATH)

--- a/configurator/src/lnd.conf.template
+++ b/configurator/src/lnd.conf.template
@@ -18,6 +18,7 @@ max-commit-fee-rate-anchors={max_commit_fee_rate_anchors}
 accept-keysend={accept_keysend}
 accept-amp={accept_amp}
 gc-canceled-invoices-on-startup={gc_canceled_invoices_on_startup}
+allow-circular-route={allow_circular_route}
 alias={alias}
 color=#{color}
 {feeurl_row}

--- a/configurator/src/main.rs
+++ b/configurator/src/main.rs
@@ -123,6 +123,7 @@ struct AdvancedConfig {
     protocol_no_anchors: bool,
     protocol_disable_script_enforced_lease: bool,
     gc_canceled_invoices_on_startup: bool,
+    allow_circular_route: bool,
     bitcoin: BitcoinChannelConfig,
 }
 
@@ -329,6 +330,7 @@ fn main() -> Result<(), anyhow::Error> {
         accept_keysend = config.accept_keysend,
         accept_amp = config.accept_amp,
         gc_canceled_invoices_on_startup = config.advanced.gc_canceled_invoices_on_startup,
+        allow_circular_route = config.advanced.allow_circular_route,
         alias = alias,
         color = config.color,
         feeurl_row = if use_neutrino {

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -2,7 +2,7 @@ id: lnd
 title: Lightning Network Daemon
 version: 0.15.0
 release-notes: |-
-  * New LND v0.15.0-beta: [Upstream Release Notes](https://github.com/lightningnetwork/lnd/releases/tag/v0.15.0-beta)  
+  * New LND v0.15.0-beta: [Upstream Release Notes](https://github.com/lightningnetwork/lnd/blob/master/docs/release-notes/release-notes-0.15.0.md)  
   * Add "Allow Circular Route" Config Option 
 license: mit
 wrapper-repo: "https://github.com/Start9Labs/lnd-wrapper"

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -1,7 +1,9 @@
 id: lnd
 title: Lightning Network Daemon
-version: 0.14.2.4
-release-notes: Fix migrations to properly handle the bitcoin configuration for updates from 0.13.x versions and ensure any version will successfully migrate to the latest version going forward
+version: 0.15.0
+release-notes: |-
+  * New LND v0.15.0-beta: [Upstream Release Notes](https://github.com/lightningnetwork/lnd/releases/tag/v0.15.0-beta)  
+  * Add "Allow Circular Route" Config Option 
 license: mit
 wrapper-repo: "https://github.com/Start9Labs/lnd-wrapper"
 upstream-repo: "https://github.com/lightningnetwork/lnd"

--- a/scripts/migrations/0_15_0__down_migration.ts
+++ b/scripts/migrations/0_15_0__down_migration.ts
@@ -2,6 +2,12 @@ import { types as T, YAML, matches } from "../deps.ts"
 
 const { shape, boolean } = matches
 
+const matchAdvanced = shape({
+  advanced: shape({
+    "allow-circular-route": boolean,
+  })
+})
+
 const matchTor = shape({
   tor: shape({
     "use-tor-only": boolean,
@@ -9,7 +15,7 @@ const matchTor = shape({
   })
 })
 
-export const migration_down_0_14_2_1: T.ExpectedExports.migration = async (effects, _version) => {
+export const migration_down_0_15_0: T.ExpectedExports.migration = async (effects, _version) => {
   await effects.createDir({
     volumeId: "main",
     path: "start9"
@@ -25,6 +31,11 @@ export const migration_down_0_14_2_1: T.ExpectedExports.migration = async (effec
     return { result: { configured: false } }
   }
 
+  // allow_circular_route was added in 0.15.0
+  if (!matchAdvanced.test(parsed)) {
+    return { result: { configured: false } }
+  }
+  
   return { result: { configured: true } }
 
 }

--- a/scripts/migrations/0_15_0__up_migration.ts
+++ b/scripts/migrations/0_15_0__up_migration.ts
@@ -2,6 +2,12 @@ import { types as T, YAML, matches, rangeOf } from "../deps.ts"
 
 const { shape, string, boolean } = matches
 
+const matchAdvanced = shape({
+  advanced: shape({
+    "allow-circular-route": boolean,
+  })
+})
+
 const matchWatch = shape({
   "watchtower-enabled": boolean,
   "watchtower-client-enabled": boolean
@@ -20,7 +26,7 @@ const matchBitcoin = shape({
   })
 })
 
-export const migration_up_0_14_2_1: T.ExpectedExports.migration = async (effects, version) => {
+export const migration_up_0_15_0: T.ExpectedExports.migration = async (effects, version) => {
   await effects.createDir({
     volumeId: "main",
     path: "start9"
@@ -69,6 +75,12 @@ export const migration_up_0_14_2_1: T.ExpectedExports.migration = async (effects
     }
   }
 
+  // allow_circular_route was added in 0.15.0
+  if (rangeOf('<0.15.0').check(version)) {
+    if (!matchAdvanced.test(parsed)) {
+      return { result: { configured: false } }
+    }
+  }
   return { result: { configured: true } }
 
 }

--- a/scripts/services/dependencies.ts
+++ b/scripts/services/dependencies.ts
@@ -72,6 +72,7 @@ const checks: Array<Check> = [
     "getrawtransaction",
     "getpeerinfo",
     "getmempoolinfo",
+    "getzmqnotifications",
   ].map(
     (operator): Check => ({
       currentError(config) {

--- a/scripts/services/getConfig.ts
+++ b/scripts/services/getConfig.ts
@@ -376,6 +376,12 @@ export const getConfig: T.ExpectedExports.getConfig = compat.getConfig({
         "description": "If true, LND will attempt to garbage collect canceled invoices upon start.\n",
         "default": false
       },
+      "allow-circular-route": {
+        "type": "boolean",
+        "name": "Allow Circular Route",
+        "description": "If true, LND will allow htlc forwards that arrive and depart on the same channel.\n",
+        "default": false
+      },
       "bitcoin": {
         "type": "object",
         "name": "Bitcoin Channel Configuration",

--- a/scripts/services/migrations.ts
+++ b/scripts/services/migrations.ts
@@ -1,20 +1,20 @@
 import { types as T, rangeOf } from "../deps.ts"
 
-import { migration_up_0_14_2_1 } from "../migrations/0_14_2_1__up_migration.ts";
-import { migration_down_0_14_2_1 } from "../migrations/0_14_2_1_down_migration.ts";
+import { migration_up_0_15_0 } from "../migrations/0_15_0__up_migration.ts";
+import { migration_down_0_15_0 } from "../migrations/0_15_0__down_migration.ts";
 
 // version here is where you are coming from ie. the version the service is currently on
 export const migration: T.ExpectedExports.migration = async (effects, version) => {
 
   // from migrations (upgrades)
-  if (rangeOf('<=0.14.2.1').check(version)) {
-    const result = await migration_up_0_14_2_1(effects,version)
+  if (rangeOf('<=0.15.0').check(version)) {
+    const result = await migration_up_0_15_0(effects,version)
     return result
   }
 
   // to migrations (downgrades)
-  if (rangeOf('>0.14.2.1').check(version)) {
-    const result = await migration_down_0_14_2_1(effects, version)
+  if (rangeOf('>0.15.0').check(version)) {
+    const result = await migration_down_0_15_0(effects, version)
     return result
   }
 


### PR DESCRIPTION
-  #62 
-  #64 

misc edits:

- Updated Makefile to have a more complete clean command
- Updated migration code to a account for new config option
- Added getzmqnotifications to lnd proxy permissions, required for LND v0.15.0-beta

